### PR TITLE
Switch from sets to compound sort keys

### DIFF
--- a/dynamodb/delete.py
+++ b/dynamodb/delete.py
@@ -13,14 +13,14 @@ table = setup_table()
 
 def lambda_handler(event, context):
     if not event.get('body'):
-        return respond({"message": "DELETE request requires parameters in the body"})
+        return respond({'message': 'DELETE request requires parameters in the body'})
 
     try:
         body = loads(event['body'])
     except:
         return respond({
-            "message": "DELETE request requires JSON parameters in the body",
-            "body": event['body']
+            'message': 'DELETE request requires JSON parameters in the body',
+            'body': event['body']
         })
 
     userid = event['requestContext']['authorizer']['jwt']['claims']['username']
@@ -63,7 +63,7 @@ def lambda_handler(event, context):
 
         return respond(None, response)
 
-    if confirm != "YES":
+    if confirm != 'YES':
         return respond({
             'message': 'removing all skills for a user requires confirm set to YES'
         })

--- a/dynamodb/mylib/response.py
+++ b/dynamodb/mylib/response.py
@@ -1,11 +1,11 @@
-import json
+from json import dumps
 
 
 def respond(err, res=None):
     if err:
-        body = json.dumps(err)
+        body = dumps(err)
     else:
-        body = json.dumps(res)
+        body = dumps(res)
 
     return {
         'statusCode': '400' if err else '200',

--- a/dynamodb/mylib/table.py
+++ b/dynamodb/mylib/table.py
@@ -1,8 +1,8 @@
-import boto3
+from boto3 import resource
 
 
 def setup_table():
     # pylint: disable=invalid-name
-    dynamodb = boto3.resource('dynamodb')
+    dynamodb = resource('dynamodb')
     TABLE_NAME = 'Skills'
     return dynamodb.Table(TABLE_NAME)

--- a/dynamodb/post.py
+++ b/dynamodb/post.py
@@ -44,7 +44,7 @@ def lambda_handler(event, context):
     sort_key = f'{rating}#{skill}'
 
     try:
-        table.put_item(Key={'PK': userid, 'SK': sort_key})
+        table.put_item(Item={'PK': userid, 'SK': sort_key})
         response = {'message': 'Skill added'}
 
     except ClientError as error:

--- a/dynamodb/post.py
+++ b/dynamodb/post.py
@@ -12,14 +12,14 @@ table = setup_table()
 
 def lambda_handler(event, context):
     if not event.get('body'):
-        return respond({"message": "POST request requires parameters in the body"})
+        return respond({'message': 'POST request requires parameters in the body'})
 
     try:
         body = json.loads(event['body'])
     except:
         return respond({
-            "message": "POST request requires JSON parameters in the body",
-            "body": event['body']
+            'message': 'POST request requires JSON parameters in the body',
+            'body': event['body']
         })
 
     userid = event['requestContext']['authorizer']['jwt']['claims']['username']

--- a/dynamodb/post.py
+++ b/dynamodb/post.py
@@ -41,10 +41,10 @@ def lambda_handler(event, context):
     if rating not in range(1, 6):
         return respond({'message': 'rating is not between 1 and 5', 'rating': rating})
 
+    sort_key = f'{rating}#{skill}'
+
     try:
-        table.update_item(Key={'userid': userid, 'rating': rating},
-                          UpdateExpression='ADD skills :skill',
-                          ExpressionAttributeValues={':skill': set([skill])})
+        table.put_item(Key={'PK': userid, 'SK': sort_key})
         response = {'message': 'Skill added'}
 
     except ClientError as error:

--- a/dynamodb/put.py
+++ b/dynamodb/put.py
@@ -1,9 +1,11 @@
-import json
-import sys
-import os
+from json import loads
+from sys import path
+from os.path import join, dirname
+from functools import reduce
+from boto3.dynamodb.conditions import Key, And
 from botocore.exceptions import ClientError
 
-sys.path.append(os.path.join(os.path.dirname(__file__)))
+path.append(join(dirname(__file__)))
 from mylib.response import respond
 from mylib.table import setup_table
 
@@ -13,7 +15,7 @@ def lambda_handler(event, context):
         return respond({"message": "PUT request requires parameters in the body"})
 
     try:
-        body = json.loads(event['body'])
+        body = loads(event['body'])
     except:
         return respond({
             "message": "PUT request requires JSON parameters in the body",
@@ -49,13 +51,18 @@ def lambda_handler(event, context):
     if newrating not in range(1, 6):
         return respond({'message': 'newrating is not between 1 and 5', 'newrating': newrating})
 
+    sk_old = f'{oldrating}#{skill}'
+    sk_new = f'{newrating}#{skill}'
+    keycondition = reduce(And, [Key('PK').eq(userid), Key('SK').eq(sk_old)])
+
     try:
-        table.update_item(Key={'userid': userid, 'rating': oldrating},
-                          UpdateExpression='DELETE skills :skill',
-                          ExpressionAttributeValues={':skill': set([skill])})
-        table.update_item(Key={'userid': userid, 'rating': newrating},
-                          UpdateExpression='ADD skills :skill',
-                          ExpressionAttributeValues={':skill': set([skill])})
+        response = table.query(KeyConditionExpression=keycondition)
+        response = response['Items']
+        if len(response) == 0:
+            return respond({'message': 'Skill does not exist with this rating'})
+
+        table.delete_item(Key={'PK': userid, 'SK': sk_old})
+        table.put_item(Key={'PK': userid, 'SK': sk_new})
         response = {'message': 'Skill updated'}
 
     except ClientError as error:

--- a/dynamodb/put.py
+++ b/dynamodb/put.py
@@ -62,7 +62,7 @@ def lambda_handler(event, context):
             return respond({'message': 'Skill does not exist with this rating'})
 
         table.delete_item(Key={'PK': userid, 'SK': sk_old})
-        table.put_item(Key={'PK': userid, 'SK': sk_new})
+        table.put_item(Item={'PK': userid, 'SK': sk_new})
         response = {'message': 'Skill updated'}
 
     except ClientError as error:

--- a/dynamodb/put.py
+++ b/dynamodb/put.py
@@ -12,14 +12,14 @@ from mylib.table import setup_table
 table = setup_table()
 def lambda_handler(event, context):
     if not event.get('body'):
-        return respond({"message": "PUT request requires parameters in the body"})
+        return respond({'message': 'PUT request requires parameters in the body'})
 
     try:
         body = loads(event['body'])
     except:
         return respond({
-            "message": "PUT request requires JSON parameters in the body",
-            "body": event['body']
+            'message': 'PUT request requires JSON parameters in the body',
+            'body': event['body']
         })
 
     userid = event['requestContext']['authorizer']['jwt']['claims']['username']

--- a/template.yaml
+++ b/template.yaml
@@ -114,12 +114,13 @@ Resources:
             Path: /Skills
             Method: get
             ApiId: !Ref ApiResource
+
   PutFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: put.lambda_handler
       Policies:
-        - DynamoDBWritePolicy:
+        - DynamoDBCrudPolicy:
             TableName: !Ref SkillsTable
       Events:
         Put:

--- a/template.yaml
+++ b/template.yaml
@@ -18,7 +18,9 @@ Parameters:
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
   Function:
-    Runtime: python3.8
+    Runtime: python3.9
+    Architectures:
+      - arm64
     CodeUri: dynamodb/
 
 Resources:

--- a/template.yaml
+++ b/template.yaml
@@ -161,14 +161,14 @@ Resources:
     Type: 'AWS::DynamoDB::Table'
     Properties:
       AttributeDefinitions:
-        - AttributeName: userid
+        - AttributeName: PK
           AttributeType: S
-        - AttributeName: rating
-          AttributeType: N
+        - AttributeName: SK
+          AttributeType: S
       KeySchema:
-        - AttributeName: userid
+        - AttributeName: PK
           KeyType: HASH
-        - AttributeName: rating
+        - AttributeName: SK
           KeyType: RANGE
       ProvisionedThroughput:
         ReadCapacityUnits: 1


### PR DESCRIPTION
Old Schema:
```
PK: userid (string)
SK: rating (integer)
Skills: Set(strings)
```

New Schema:
```
PK: userid (string)
SK: rating (iinteger) + '#' + skill (string)
```

This moves from combining all skills with the same rating for a user into a single record,
to using a record for each skill.

This also uses the basics of single table design, although it has little effect on the performance of this API.